### PR TITLE
Cad refactor and bd 090 compliance

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ Homepage = "https://github.com/GarryBGoode/gggears"
 numpy = "^2.0.0"
 scipy = "^1.10.1"
 build123d = "^0.8.0"
+joblib = "^1.4.2"
 
 [project.optional-dependencies]
 dev = [

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ pytest-xdist
 shapely
 matplotlib
 ocp-vscode
+joblib

--- a/src/gggears/gggears_convert.py
+++ b/src/gggears/gggears_convert.py
@@ -12,7 +12,6 @@
 import gggears.gggears_core as gg
 import numpy as np
 from joblib import Parallel, delayed
-import multiprocessing
 import gggears.curve as crv
 from scipy.optimize import minimize
 from gggears.defs import *
@@ -91,7 +90,7 @@ class GearToNurbs:
         return nurb_stack
     
     def generate_nurbs(self):
-        return list(Parallel(n_jobs=multiprocessing.cpu_count())(delayed(self.generate_nurbs_job)(gear_stack) for gear_stack in self.gear_stacks))
+        return list(Parallel(n_jobs=-1, prefer="threads")(delayed(self.generate_nurbs_job)(gear_stack) for gear_stack in self.gear_stacks))
 
     def generate_gear_stacks_job(self, ii) -> List[gg.GearRefProfileExtended]:
         # need more gear slices than nurb points to produce 'best' fit without overfitting
@@ -108,7 +107,7 @@ class GearToNurbs:
         ]
 
     def generate_gear_stacks(self) -> List[List[gg.GearRefProfileExtended]]:
-        return list(Parallel(n_jobs=multiprocessing.cpu_count())(delayed(self.generate_gear_stacks_job)(ii) for ii in range(len(self.z_vals) - 1)))
+        return list(Parallel(n_jobs=-1, prefer="threads")(delayed(self.generate_gear_stacks_job)(ii) for ii in range(len(self.z_vals) - 1)))
 
     def generate_surface_points_sides_job(self, method, ii):
         nurb_profile_stack = self.nurb_profile_stacks[ii]
@@ -156,7 +155,7 @@ class GearToNurbs:
         )
 
     def generate_surface_points_sides(self, method="fast"):
-        return list(Parallel(n_jobs=multiprocessing.cpu_count())(delayed(self.generate_surface_points_sides_job)(method, ii) for ii in range(len(self.z_vals) - 1)))        
+        return list(Parallel(n_jobs=-1, prefer="threads")(delayed(self.generate_surface_points_sides_job)(method, ii) for ii in range(len(self.z_vals) - 1)))        
 
     def solve_surface(
         self, target_points, n_points_vert=4, t_weight=0.01, init_points=None


### PR DESCRIPTION
parallelized GearToNurb::generate_nurbs(), GearToNurb::generate_gear_stacks() and GearToNurb::generate_surface_points_sides()

The code base also compiles with dev branch of build123d as at 20 January 2025.

fixes #4 

TODO: use perf profiler to identify other performance bottlenecks

https://docs.python.org/3.12/howto/perf_profiling.html

@GarryBGoode Are you aware of any other computation-intensive for-loops, or scipy / numpy calls in anywhere of the gggears code?  I am only new to gggears, so I am not yet familiar with its algorithms.