### PR TITLE
Harmonize with build123d 0.9.1, update README.md and enhance the github workflow

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,19 +16,18 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install flake8 pytest
-        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+        python -m pip install .[all]
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names

--- a/README.md
+++ b/README.md
@@ -2,13 +2,14 @@
 A gear generator in python.
 
 # Installation
-Currently the recommended way is to clone or download this repository, install dependencies from `requirements.txt` and then install gggears.
-
+Currently the recommended way for most users to install gggears is to install from github directly (git is required on the user's system for this):
 ```
-pip install -r requirements.txt
-pip install .
+python -m pip install git+https://github.com/GarryBGoode/gggears
 ```
-
+Alternatively, one can clone or download this repository and install via this command from the repository root directory:
+```
+python -m pip install .
+```
 There is an ongoing version-mismatch issue with build123d, ocp-vscode and ocp-cadquery packages. Obtaining dependencies via `pip` might cause problems. If using OCP VSCode for the first time, `quickstart with build123d` might cause problems because it grabs the newest version from build123d github. If build123d is already installed, use the 'package manager' window instead.
 
 For compatibility with dev version of build123d, use gggears branch `CAD_refactor_and_bd_090_compliance`.
@@ -16,13 +17,10 @@ Follow [this issue for details.](https://github.com/gumyr/build123d/issues/866)
 
 # Dependencies
 
-Gggears CAD model creation uses build123d package: [build-123d github](https://github.com/gumyr/build123d)
-
-gggears main depends on build123d 0.8.0, while gggears branch `CAD_refactor_and_bd_090_compliance` is compatible with build123d `dev` branch (planned v0.9.0).
+Gggears CAD model creation uses build123d package: [build123d github](https://github.com/gumyr/build123d)
 
 It is highly recommended, though not strictly necessary to use a python-CAD gui solution.
 See [OCP VSCode](https://github.com/bernhard-42/vscode-ocp-cad-viewer) and [CadQuery Editor](https://github.com/CadQuery/CQ-editor).
-
 
 # Documentation
 Docs hosted on [readthedocs](https://gggears.readthedocs.io/en/latest/)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,22 @@ dev = [
     "ocp-vscode"
 ]
 
+ocp_vscode = [
+    "ocp_vscode",
+]
+
+extras = [
+    "matplotlib",
+    "pyqt6",
+    "PyQt6-WebEngine",
+]
+
+all = [
+    "gggears[dev]"
+    "gggears[ocp_vscode]"
+    "gggears[extras]"
+]
+
 [build-system]
 requires = ["setuptools>=42", "wheel"]
 build-backend = "setuptools.build_meta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,8 @@ dev = [
     "pytest-xdist",
     "shapely",
     "matplotlib",
-    "ocp-vscode"
+    "ocp-vscode",
+    "flake8",
 ]
 
 ocp_vscode = [
@@ -42,9 +43,9 @@ extras = [
 ]
 
 all = [
-    "gggears[dev]"
-    "gggears[ocp_vscode]"
-    "gggears[extras]"
+    "gggears[dev]",
+    "gggears[ocp_vscode]",
+    "gggears[extras]",
 ]
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,18 +1,18 @@
 [project]
 name = "gggears"
-version = "0.0.12"
+version = "0.0.13"
 description = "A gear geometry generator in Python"
 authors = [
 { name = "Gergely Bencsik", email = "bencsik.gergely.1@gmail.com"},
 ]
 readme="README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 classifiers = [
 "Programming Language :: Python :: 3",
 "License :: OSI Approved :: Apache-2.0",
 "Operating System :: OS Independent",
 ]
-keywords = ["gears","CAD", "python"]
+keywords = ["gears", "CAD", "python"]
 
 [project_urls]
 Homepage = "https://github.com/GarryBGoode/gggears"
@@ -20,7 +20,7 @@ Homepage = "https://github.com/GarryBGoode/gggears"
 [dependencies]
 numpy = "^2.0.0"
 scipy = "^1.10.1"
-build123d = "^0.8.0"
+build123d = "^0.9.1"
 
 [project.optional-dependencies]
 dev = [
@@ -40,7 +40,7 @@ packages = ["gggears"]
 package-dir = {"" = "src"}
 
 [tool.black]
-target-version = ["py39", "py310", "py311", "py312"]
+target-version = ["py310", "py311", "py312", "py313"]
 line-length = 88
 
 [tool.isort]
@@ -53,10 +53,10 @@ testpaths = ["tests"]
 pythonpath = "src"
 
 [tool.mypy]
-python_version = "3.9"
+python_version = "3.10"
 warn_return_any = true
 warn_unused_configs = true
 
 [tool.ruff]
-lint.select = ["E","F", "W", "B"]
+lint.select = ["E", "F", "W", "B"]
 lint.ignore = ["F403", "F405"]


### PR DESCRIPTION
I have attempted to provide a few improvements to gggears including some changes to pyproject.toml. These changes incorporate python best-practices by separating optional dependencies into their own categories. I created a few additional categories to help cover everything that was in requirements.txt. I also consequently de-emphasized requirements.txt in README.md since it should suffice to rely on pyproject.toml instead. build123d 0.9.x dropped support for python 3.9, so I removed that version and added python 3.13. I made some matching changes in the github workflow to reflect this as well and prevent failed CI runs that you may have been seeing.

Speaking of README.md I added an additional simpler installation method as the current recommended approach (until gggears becomes available on pypi). This does not require the user to first clone the repo, and instead allows the user to pip install from github directly in one command.

Eventually I think it would be best to simply delete requirements.txt as it is redundant to the dependencies contained within pyproject.toml. I did not do that in this PR as it was already quite a few changes.